### PR TITLE
Catch iterator variable to avoid potential concurrent error in tests

### DIFF
--- a/test/e2e/terraform_test.go
+++ b/test/e2e/terraform_test.go
@@ -16,9 +16,10 @@ func TestExamplesBasic(t *testing.T) {
 		false, true,
 	}
 	for _, publicIp := range createPublicIp {
-		t.Run(fmt.Sprintf("createPublicIp-%t", publicIp), func(t *testing.T) {
+		pip := publicIp
+		t.Run(fmt.Sprintf("createPublicIp-%t", pip), func(t *testing.T) {
 			vars := map[string]interface{}{
-				"create_public_ip": publicIp,
+				"create_public_ip": pip,
 			}
 			managedIdentityId := os.Getenv("MSI_ID")
 			if managedIdentityId != "" {
@@ -35,7 +36,7 @@ func TestExamplesBasic(t *testing.T) {
 				windowsVmId, ok := output["windows_vm_id"]
 				assert.True(t, ok)
 				assert.Regexp(t, vmIdRegex, windowsVmId)
-				if publicIp {
+				if pip {
 					linuxPublicIp, ok := output["linux_public_ip"].(string)
 					assert.True(t, ok)
 					windowsPublicIp, ok := output["windows_public_ip"].(string)

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -1,62 +1,64 @@
 package upgrade
 
 import (
-	"fmt"
-	"os"
-	"testing"
+  "fmt"
+  "os"
+  "testing"
 
-	test_helper "github.com/Azure/terraform-module-test-helper"
-	"github.com/gruntwork-io/terratest/modules/terraform"
+  test_helper "github.com/Azure/terraform-module-test-helper"
+  "github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestExampleUpgrade_basic(t *testing.T) {
-	createPublicIp := []bool{
-		false, true,
-	}
-	for _, create := range createPublicIp {
-		t.Run(fmt.Sprintf("createPublicIp-%t", create), func(t *testing.T) {
-			currentRoot, err := test_helper.GetCurrentModuleRootPath()
-			if err != nil {
-				t.FailNow()
-			}
-			currentMajorVersion, err := test_helper.GetCurrentMajorVersionFromEnv()
-			if err != nil {
-				t.FailNow()
-			}
-			vars := map[string]interface{}{
-				"create_public_ip": create,
-			}
-			managedIdentityId := os.Getenv("MSI_ID")
-			if managedIdentityId != "" {
-				vars["managed_identity_principal_id"] = managedIdentityId
-			}
-			test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-virtual-machine", "examples/basic", currentRoot, terraform.Options{
-				Upgrade: true,
-				Vars:    vars,
-			}, currentMajorVersion)
-		})
-	}
+  createPublicIp := []bool{
+    false, true,
+  }
+  for _, create := range createPublicIp {
+    pip := create
+    t.Run(fmt.Sprintf("createPublicIp-%t", pip), func(t *testing.T) {
+      currentRoot, err := test_helper.GetCurrentModuleRootPath()
+      if err != nil {
+        t.FailNow()
+      }
+      currentMajorVersion, err := test_helper.GetCurrentMajorVersionFromEnv()
+      if err != nil {
+        t.FailNow()
+      }
+      vars := map[string]interface{}{
+        "create_public_ip": pip,
+      }
+      managedIdentityId := os.Getenv("MSI_ID")
+      if managedIdentityId != "" {
+        vars["managed_identity_principal_id"] = managedIdentityId
+      }
+      test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-virtual-machine", "examples/basic", currentRoot, terraform.Options{
+        Upgrade: true,
+        Vars:    vars,
+      }, currentMajorVersion)
+    })
+  }
 }
 
 func TestExampleUpgrade(t *testing.T) {
-	examples := []string{
-		"availability_set",
-		"dedicated_host",
-		"vmss",
-	}
-	for _, example := range examples {
-		t.Run(example, func(t *testing.T) {
-			currentRoot, err := test_helper.GetCurrentModuleRootPath()
-			if err != nil {
-				t.FailNow()
-			}
-			currentMajorVersion, err := test_helper.GetCurrentMajorVersionFromEnv()
-			if err != nil {
-				t.FailNow()
-			}
-			test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-virtual-machine", fmt.Sprintf("examples/%s", example), currentRoot, terraform.Options{
-				Upgrade: true,
-			}, currentMajorVersion)
-		})
-	}
+  examples := []string{
+    "availability_set",
+    "dedicated_host",
+    "vmss",
+  }
+  for _, example := range examples {
+    e := example
+    t.Run(e, func(t *testing.T) {
+      currentRoot, err := test_helper.GetCurrentModuleRootPath()
+      if err != nil {
+        t.FailNow()
+      }
+      currentMajorVersion, err := test_helper.GetCurrentMajorVersionFromEnv()
+      if err != nil {
+        t.FailNow()
+      }
+      test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-virtual-machine", fmt.Sprintf("examples/%s", e), currentRoot, terraform.Options{
+        Upgrade: true,
+      }, currentMajorVersion)
+    })
+  }
 }

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -1,64 +1,64 @@
 package upgrade
 
 import (
-  "fmt"
-  "os"
-  "testing"
+	"fmt"
+	"os"
+	"testing"
 
-  test_helper "github.com/Azure/terraform-module-test-helper"
-  "github.com/gruntwork-io/terratest/modules/terraform"
+	test_helper "github.com/Azure/terraform-module-test-helper"
+	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestExampleUpgrade_basic(t *testing.T) {
-  createPublicIp := []bool{
-    false, true,
-  }
-  for _, create := range createPublicIp {
-    pip := create
-    t.Run(fmt.Sprintf("createPublicIp-%t", pip), func(t *testing.T) {
-      currentRoot, err := test_helper.GetCurrentModuleRootPath()
-      if err != nil {
-        t.FailNow()
-      }
-      currentMajorVersion, err := test_helper.GetCurrentMajorVersionFromEnv()
-      if err != nil {
-        t.FailNow()
-      }
-      vars := map[string]interface{}{
-        "create_public_ip": pip,
-      }
-      managedIdentityId := os.Getenv("MSI_ID")
-      if managedIdentityId != "" {
-        vars["managed_identity_principal_id"] = managedIdentityId
-      }
-      test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-virtual-machine", "examples/basic", currentRoot, terraform.Options{
-        Upgrade: true,
-        Vars:    vars,
-      }, currentMajorVersion)
-    })
-  }
+	createPublicIp := []bool{
+		false, true,
+	}
+	for _, create := range createPublicIp {
+		pip := create
+		t.Run(fmt.Sprintf("createPublicIp-%t", pip), func(t *testing.T) {
+			currentRoot, err := test_helper.GetCurrentModuleRootPath()
+			if err != nil {
+				t.FailNow()
+			}
+			currentMajorVersion, err := test_helper.GetCurrentMajorVersionFromEnv()
+			if err != nil {
+				t.FailNow()
+			}
+			vars := map[string]interface{}{
+				"create_public_ip": pip,
+			}
+			managedIdentityId := os.Getenv("MSI_ID")
+			if managedIdentityId != "" {
+				vars["managed_identity_principal_id"] = managedIdentityId
+			}
+			test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-virtual-machine", "examples/basic", currentRoot, terraform.Options{
+				Upgrade: true,
+				Vars:    vars,
+			}, currentMajorVersion)
+		})
+	}
 }
 
 func TestExampleUpgrade(t *testing.T) {
-  examples := []string{
-    "availability_set",
-    "dedicated_host",
-    "vmss",
-  }
-  for _, example := range examples {
-    e := example
-    t.Run(e, func(t *testing.T) {
-      currentRoot, err := test_helper.GetCurrentModuleRootPath()
-      if err != nil {
-        t.FailNow()
-      }
-      currentMajorVersion, err := test_helper.GetCurrentMajorVersionFromEnv()
-      if err != nil {
-        t.FailNow()
-      }
-      test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-virtual-machine", fmt.Sprintf("examples/%s", e), currentRoot, terraform.Options{
-        Upgrade: true,
-      }, currentMajorVersion)
-    })
-  }
+	examples := []string{
+		"availability_set",
+		"dedicated_host",
+		"vmss",
+	}
+	for _, example := range examples {
+		e := example
+		t.Run(e, func(t *testing.T) {
+			currentRoot, err := test_helper.GetCurrentModuleRootPath()
+			if err != nil {
+				t.FailNow()
+			}
+			currentMajorVersion, err := test_helper.GetCurrentMajorVersionFromEnv()
+			if err != nil {
+				t.FailNow()
+			}
+			test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-virtual-machine", fmt.Sprintf("examples/%s", e), currentRoot, terraform.Options{
+				Upgrade: true,
+			}, currentMajorVersion)
+		})
+	}
 }


### PR DESCRIPTION
## Describe your changes

We have a classic `foreach` error in our go test code, it would cause randomly error when we try to execute tests concurrently, this pull request capture the iterator variable into a local variable to avoid such error.

## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

