### PR TITLE
fix: update minimum terraform version to 1.3.5

### DIFF
--- a/examples/availability_set/providers.tf
+++ b/examples/availability_set/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3.5"
 
   required_providers {
     azurerm = {

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3.5"
 
   required_providers {
     azurerm = {

--- a/examples/dedicated_host/providers.tf
+++ b/examples/dedicated_host/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3.5"
 
   required_providers {
     azurerm = {

--- a/examples/extensions/providers.tf
+++ b/examples/extensions/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3.5"
 
   required_providers {
     azurerm = {

--- a/examples/vmss/providers.tf
+++ b/examples/vmss/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3.5"
 
   required_providers {
     azurerm = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3.5"
 
   required_providers {
     azurerm = {


### PR DESCRIPTION
Current examples do not run due to a bug fixed in terraform 1.3.5. Previous terraform versions fail with the message:
```
╷
│ Error: Unsupported attribute
│
│   on ../../main.tf line 159, in resource "azurerm_linux_virtual_machine" "vm_linux":
│  159:         option    = var.os_disk.diff_disk_settings.option
│     ├────────────────
│     │ var.os_disk.diff_disk_settings is object with 1 attribute "placement"
│
│ This object does not have an attribute named "option".
```

## Describe your changes

Update minimum required Terraform version from 1.2 to 1.3.5 

## Issue number

#000

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

