### PR TITLE
Update deprecated variable names 'enable_accelerated_networking' and 'enabled_ip_forwarding'

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -549,7 +549,7 @@ resource "azurerm_network_interface" "vm" {
   resource_group_name           = var.resource_group_name
   dns_servers                   = var.new_network_interface.dns_servers
   edge_zone                     = var.new_network_interface.edge_zone
-  enable_accelerated_networking = var.new_network_interface.accelerated_networking_enabled
+  accelerated_networking_enabled = var.new_network_interface.accelerated_networking_enabled
   #checkov:skip=CKV_AZURE_118
   enable_ip_forwarding    = var.new_network_interface.ip_forwarding_enabled
   internal_dns_name_label = var.new_network_interface.internal_dns_name_label

--- a/main.tf
+++ b/main.tf
@@ -551,7 +551,7 @@ resource "azurerm_network_interface" "vm" {
   edge_zone                     = var.new_network_interface.edge_zone
   accelerated_networking_enabled = var.new_network_interface.accelerated_networking_enabled
   #checkov:skip=CKV_AZURE_118
-  enable_ip_forwarding    = var.new_network_interface.ip_forwarding_enabled
+  ip_forwarding_enabled    = var.new_network_interface.ip_forwarding_enabled
   internal_dns_name_label = var.new_network_interface.internal_dns_name_label
   tags = merge(var.tags, (/*<box>*/ (var.tracing_tags_enabled ? { for k, v in /*</box>*/ {
     avm_git_commit           = "c6c30c1119c3d25829b29efc3cc629b5d4767301"

--- a/main.tf
+++ b/main.tf
@@ -544,14 +544,14 @@ locals {
 resource "azurerm_network_interface" "vm" {
   count = var.new_network_interface != null ? 1 : 0
 
-  location                      = var.location
-  name                          = coalesce(var.new_network_interface.name, "${var.name}-nic")
-  resource_group_name           = var.resource_group_name
-  dns_servers                   = var.new_network_interface.dns_servers
-  edge_zone                     = var.new_network_interface.edge_zone
+  location                       = var.location
+  name                           = coalesce(var.new_network_interface.name, "${var.name}-nic")
+  resource_group_name            = var.resource_group_name
+  dns_servers                    = var.new_network_interface.dns_servers
+  edge_zone                      = var.new_network_interface.edge_zone
   accelerated_networking_enabled = var.new_network_interface.accelerated_networking_enabled
   #checkov:skip=CKV_AZURE_118
-  ip_forwarding_enabled    = var.new_network_interface.ip_forwarding_enabled
+  ip_forwarding_enabled   = var.new_network_interface.ip_forwarding_enabled
   internal_dns_name_label = var.new_network_interface.internal_dns_name_label
   tags = merge(var.tags, (/*<box>*/ (var.tracing_tags_enabled ? { for k, v in /*</box>*/ {
     avm_git_commit           = "c6c30c1119c3d25829b29efc3cc629b5d4767301"


### PR DESCRIPTION
## Describe your changes
Updated the deprecated variable names to the official current ones.

Update variable from 'enabled_ip_forwarding' to '[ip_forwarding_enabled](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface#ip_forwarding_enabled)'
Update variable from 'enable_accelerated_networking' to '[accelerated_networking_enabled](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface#accelerated_networking_enabled)'

## Issue number
#73

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

